### PR TITLE
Use std::time instead of time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ documentation = "http://tailhook.github.io/signal/"
 [dependencies]
 nix = "0.4.1"
 libc = "0.1.10"
-time = "0.1.32"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 
 extern crate libc;
 extern crate nix;
-extern crate time;
 
 mod ffi;
 pub mod exec_handler;

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -34,7 +34,7 @@ containers:
     - !Install [libreadline-dev] # for lua
 
     - !TarInstall
-      url: "http://static.rust-lang.org/dist/rust-1.7.0-x86_64-unknown-linux-gnu.tar.gz"
+      url: "https://static.rust-lang.org/dist/rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz"
       script: "./install.sh --prefix=/usr \
                --components=rustc,rust-std-x86_64-unknown-linux-gnu,cargo"
 


### PR DESCRIPTION
Replaces all usages of the time crate by the
appropriate types in std::time.

Also bumps Rust to 1.9, to gain access to std::time
features.