### PR TITLE
Add Send impl to Trap; fix compilation error on nightly

### DIFF
--- a/src/trap.rs
+++ b/src/trap.rs
@@ -21,11 +21,11 @@ use libc::{self, timespec};
 use ffi::{sigwait, sigtimedwait};
 
 /// A RAII guard for masking out signals and waiting for them synchronously
-//!
-//! Trap temporarily replaces signal handlers to an empty handler, effectively
-//! activating singnals that are ignored by default.
-//!
-//! Old signal handlers are restored in `Drop` handler.
+///
+/// Trap temporarily replaces signal handlers to an empty handler, effectively
+/// activating singnals that are ignored by default.
+///
+/// Old signal handlers are restored in `Drop` handler.
 pub struct Trap {
     oldset: SigSet,
     oldsigs: Vec<(SigNum, SigAction)>,
@@ -102,6 +102,8 @@ impl Trap {
         }
     }
 }
+
+unsafe impl Send for Trap {}
 
 impl Iterator for Trap {
     type Item = SigNum;


### PR DESCRIPTION
Great work on this library! I ran into an issue using it, however. I could be using it wrong, so if so, please let me know! In my app ([watchexec](https://github.com/mattgreen/watchexec)), I'm [handling signals in a background thread](https://github.com/mattgreen/watchexec/blob/a408975bdcf93f51752bd1fd654b4a45bdf1c807/src/interrupt_handler.rs#L20) using a `Trap`, and notifying the main thread via a channel.

Under macOS, `Trap`s can be moved to another thread, like in my example. However, under Linux, this generates the following error message:

```
error[E0277]: the trait bound `*mut libc::c_void: std::marker::Send` is not satisfied
  --> src/interrupt_handler.rs:19:5
   |
19 |     thread::spawn(move || {
   |     ^^^^^^^^^^^^^ trait `*mut libc::c_void: std::marker::Send` not satisfied
   |
   = note: `*mut libc::c_void` cannot be sent between threads safely
   = note: required because it appears within the type `libc::sigaction`
   = note: required because it appears within the type `nix::sys::signal::SigAction`
   = note: required because it appears within the type `(i32, nix::sys::signal::SigAction)`
   = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(i32, nix::sys::signal::SigAction)>`
   = note: required because it appears within the type `alloc::raw_vec::RawVec<(i32, nix::sys::signal::SigAction)>`
   = note: required because it appears within the type `std::vec::Vec<(i32, nix::sys::signal::SigAction)>`
   = note: required because it appears within the type `signal::trap::Trap`
```

This patch simply uses the default impl for `Send` to enable this behavior.

Also I had to edit the comment formatting to get this module to compile under Rust nightly 1.14.